### PR TITLE
fix: replace missing fs require

### DIFF
--- a/start.js
+++ b/start.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const cluster = require("cluster");
 const process = require("process");
 const wrangler = require("./lib/wrangler");


### PR DESCRIPTION
Noticed `fs` was not defined in the latest version.
Added `const fs = require("fs");` to the top of the file to fix that error.