### PR TITLE
feat: Remaining KV Functions, File-System KV Store, Cache API Stubs, Workers Sites Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,6 @@ provided by KV_NAMESPACES.
 
 If a wrangler.toml file containing a `[site]` section with a `bucket` directory is loaded, the Workers Sites
 default KV namespace and manifest will be added to the worker's scope. Calls to `getAssetFromKV` will always
-return the latest version of an asset in the `bucket` directory.
+return the latest version of an asset in the `bucket` directory. Note that you'll need to bundle your worker
+code (with Webpack for instance) before running it to use `@cloudflare/kv-asset-handler`, as `import`/
+`require` are not in workers' scopes.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ nodemon --watch /path/to/worker.js --signal SIGHUP --exec 'cloudflare-worker-l
 * Cloudflare key value store if you pass in the KV_NAMESPACE environment variable
 * Cloudflare [event.passThroughOnException()](https://workers.cloudflare.com/docs/reference/workers-concepts/fetch-event-lifecycle/#passthroughonexception) for runtime exception handling
 * Cloudflare Environment Variables and Secrets loaded from a wrangler.toml
+* Workers Sites
 * ... this list should probably have more things
 
 ## Contributors
@@ -42,6 +43,7 @@ $ nodemon --watch /path/to/worker.js --signal SIGHUP --exec 'cloudflare-worker-l
 * Jeremy Danyow (@jdanyow)
 * Rita Liu (@rita-liu)
 * Nolan Woods (@innovate-invent)
+* Brendan Coll (@mrbbot)
 
 ## Future enhancements
 
@@ -67,6 +69,11 @@ Optionally, these variables are available as well:
 MINIO_PORT, MINIO_USE_SSL, MINIO_REGION, MINIO_TRANSPORT, MINIO_SESSIONTOKEN, and MINIO_PARTSIZE 
 
 See [the Minio documentation](https://docs.min.io/docs/javascript-client-api-reference.html) for details on the various parameters.
+
+## CloudFlare KV Store emulation using the File System
+
+To use the File System as the KV store simply provide the KV_FILE_ROOT option as an environment
+variable. A directory will be created in here for each KV namespace.
 
 ## CloudFlare Environment Variables and Secrets
 
@@ -96,3 +103,9 @@ Two features are provided while loading the wrangler.toml:
 
 Additionally, any 'kv-namespaces' in the wrangler.toml will be appended to the list of namespaces
 provided by KV_NAMESPACES.
+
+## Workers Sites
+
+If a wrangler.toml file containing a `[site]` section with a `bucket` directory is loaded, the Workers Sites
+default KV namespace and manifest will be added to the worker's scope. Calls to `getAssetFromKV` will always
+return the latest version of an asset in the `bucket` directory.

--- a/app/__tests__/kv-namespace_spec.js
+++ b/app/__tests__/kv-namespace_spec.js
@@ -1,0 +1,599 @@
+const { KVNamespace } = require('../kv-namespace');
+const { InMemoryKVStore } = require('../in-memory-kv-store');
+
+const TEST_NAMESPACE = 'TEST_NAMESPACE';
+
+function createNamespace(initialData) {
+  const store = new InMemoryKVStore();
+  store.values[TEST_NAMESPACE] = initialData || {};
+  return [store.getClient(TEST_NAMESPACE), store];
+}
+
+describe('kv-namespace', () => {
+  beforeEach(() => {
+    // Reset getTimestamp function before each test
+    KVNamespace.getTimestamp = () => 5000;
+  });
+
+  describe('get', () => {
+    test('it gets text by default', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: 'value',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      expect(await ns.get('key')).toBe('value');
+    });
+
+    test('it gets text', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: 'value',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      expect(await ns.get('key', 'text')).toBe('value');
+    });
+
+    test('it gets json', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: '{"field": "value"}',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      expect(await ns.get('key', 'json')).toStrictEqual({ field: 'value' });
+    });
+
+    test('it gets array buffers', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: '\x01\x02\x03',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      expect(new Uint8Array(await ns.get('key', 'arrayBuffer'))).toStrictEqual(new Uint8Array([1, 2, 3]));
+    });
+
+    test('it fails to get streams', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: '\x01\x02\x03',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      expect.assertions(1);
+      await expect(ns.get('key', 'stream')).rejects.toStrictEqual(new Error('Type "stream" is not supported!'));
+    });
+
+    test('it returns null for non-existent keys', async () => {
+      const [ns] = createNamespace();
+      await expect(await ns.get('key')).toBeNull();
+    });
+
+    test('it returns null for and removes expired keys', async () => {
+      const [ns, store] = createNamespace({
+        key: {
+          value: 'value',
+          expiration: 1000,
+          metadata: null,
+        },
+      });
+      await expect(store.values[TEST_NAMESPACE].key).toBeDefined();
+      await expect(await ns.get('key')).toBeNull();
+      await expect(store.values[TEST_NAMESPACE].key).toBeUndefined();
+    });
+  });
+
+  describe('getWithMetadata', () => {
+    test('it gets text by default with metadata', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: 'value',
+          expiration: -1,
+          metadata: { testing: true },
+        },
+      });
+      expect(await ns.getWithMetadata('key')).toStrictEqual({
+        value: 'value',
+        metadata: { testing: true },
+      });
+    });
+
+    test('it gets text with metadata', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: 'value',
+          expiration: -1,
+          metadata: { testing: true },
+        },
+      });
+      expect(await ns.getWithMetadata('key', 'text')).toStrictEqual({
+        value: 'value',
+        metadata: { testing: true },
+      });
+    });
+
+    test('it gets json with metadata', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: '{"field": "value"}',
+          expiration: -1,
+          metadata: { testing: true },
+        },
+      });
+      expect(await ns.getWithMetadata('key', 'json')).toStrictEqual({
+        value: { field: 'value' },
+        metadata: { testing: true },
+      });
+    });
+
+    test('it gets array buffers with metadata', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: '\x01\x02\x03',
+          expiration: -1,
+          metadata: { testing: true },
+        },
+      });
+      const { value, metadata } = await ns.getWithMetadata('key', 'arrayBuffer');
+      expect({
+        value: new Uint8Array(value),
+        metadata,
+      }).toStrictEqual({
+        value: new Uint8Array([1, 2, 3]),
+        metadata: { testing: true },
+      });
+    });
+
+    test('it fails to get streams with metadata', async () => {
+      const [ns] = createNamespace({
+        key: {
+          value: '\x01\x02\x03',
+          expiration: -1,
+          metadata: { testing: true },
+        },
+      });
+      expect.assertions(1);
+      await expect(ns.getWithMetadata('key', 'stream')).rejects.toStrictEqual(
+        new Error('Type "stream" is not supported!')
+      );
+    });
+
+    test('it returns null for non-existent keys with metadata', async () => {
+      const [ns] = createNamespace();
+      await expect(await ns.getWithMetadata('key')).toStrictEqual({
+        value: null,
+        metadata: null,
+      });
+    });
+
+    test('it returns null for and removes expired keys with metadata', async () => {
+      const [ns, store] = createNamespace({
+        key: {
+          value: 'value',
+          expiration: 1000,
+          metadata: { testing: true },
+        },
+      });
+      await expect(store.values[TEST_NAMESPACE].key).toBeDefined();
+      await expect(await ns.getWithMetadata('key')).toStrictEqual({
+        value: null,
+        metadata: null,
+      });
+      await expect(store.values[TEST_NAMESPACE].key).toBeUndefined();
+    });
+  });
+
+  describe('put', () => {
+    test('it puts text', async () => {
+      const [ns, store] = createNamespace();
+      await ns.put('key', 'value');
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: 'value',
+        expiration: -1,
+        metadata: null,
+      });
+    });
+
+    test('it puts array buffers', async () => {
+      const [ns, store] = createNamespace();
+      await ns.put('key', new Uint8Array([1, 2, 3]).buffer);
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: '\x01\x02\x03',
+        expiration: -1,
+        metadata: null,
+      });
+    });
+
+    test('it puts text with expiration', async () => {
+      const [ns, store] = createNamespace();
+      await ns.put('key', 'value', { expiration: 1000 });
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: 'value',
+        expiration: 1000,
+        metadata: null,
+      });
+    });
+
+    test('it puts text with string expiration', async () => {
+      const [ns, store] = createNamespace();
+      await ns.put('key', 'value', { expiration: '1000' });
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: 'value',
+        expiration: 1000,
+        metadata: null,
+      });
+    });
+
+    test('it puts text with expiration ttl', async () => {
+      KVNamespace.getTimestamp = () => 1000;
+      const [ns, store] = createNamespace();
+      await ns.put('key', 'value', { expirationTtl: 1000 });
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: 'value',
+        expiration: 2000,
+        metadata: null,
+      });
+    });
+
+    test('it puts text with string expiration ttl', async () => {
+      KVNamespace.getTimestamp = () => 1000;
+      const [ns, store] = createNamespace();
+      await ns.put('key', 'value', { expirationTtl: '1000' });
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: 'value',
+        expiration: 2000,
+        metadata: null,
+      });
+    });
+
+    test('it puts text with metadata', async () => {
+      const [ns, store] = createNamespace();
+      await ns.put('key', 'value', { metadata: { testing: true } });
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: 'value',
+        expiration: -1,
+        metadata: { testing: true },
+      });
+    });
+
+    test('it puts text with expiration and metadata', async () => {
+      const [ns, store] = createNamespace();
+      await ns.put('key', 'value', {
+        expiration: 1000,
+        metadata: { testing: true },
+      });
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: 'value',
+        expiration: 1000,
+        metadata: { testing: true },
+      });
+    });
+
+    test('it puts text with expiration ttl and metadata', async () => {
+      KVNamespace.getTimestamp = () => 1000;
+      const [ns, store] = createNamespace();
+      await ns.put('key', 'value', {
+        expirationTtl: 1000,
+        metadata: { testing: true },
+      });
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: 'value',
+        expiration: 2000,
+        metadata: { testing: true },
+      });
+    });
+
+    test('it overrides existing keys', async () => {
+      const [ns, store] = createNamespace({
+        key: {
+          value: 'value',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      await ns.put('key', 'value2', {
+        expiration: 1000,
+        metadata: { testing: true },
+      });
+      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
+        value: 'value2',
+        expiration: 1000,
+        metadata: { testing: true },
+      });
+    });
+  });
+
+  describe('delete', () => {
+    test('it deletes existing keys', async () => {
+      const [ns, store] = createNamespace({
+        key: {
+          value: 'value',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      await ns.delete('key');
+      await expect(store.values[TEST_NAMESPACE].key).toBeUndefined();
+    });
+
+    test('it does nothing for non-existent keys', async () => {
+      const [ns] = createNamespace({});
+      await ns.delete('key');
+    });
+  });
+
+  describe('list', () => {
+    test('it lists keys in sorted order', async () => {
+      const [ns] = createNamespace({
+        key3: {
+          value: 'value3',
+          expiration: -1,
+          metadata: null,
+        },
+        key1: {
+          value: 'value1',
+          expiration: -1,
+          metadata: null,
+        },
+        key2: {
+          value: 'value2',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      expect(await ns.list()).toEqual({
+        keys: [{ name: 'key1' }, { name: 'key2' }, { name: 'key3' }],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+
+    test('it lists keys matching prefix', async () => {
+      const [ns] = createNamespace({
+        section1key1: {
+          value: 'value11',
+          expiration: -1,
+          metadata: null,
+        },
+        section1key2: {
+          value: 'value12',
+          expiration: -1,
+          metadata: null,
+        },
+        section2key1: {
+          value: 'value21',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      expect(await ns.list({ prefix: 'section1' })).toEqual({
+        keys: [{ name: 'section1key1' }, { name: 'section1key2' }],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+
+    test('it lists keys with metadata', async () => {
+      const [ns] = createNamespace({
+        key1: {
+          value: 'value1',
+          expiration: -1,
+          metadata: { testing: 1 },
+        },
+        key2: {
+          value: 'value2',
+          expiration: -1,
+          metadata: { testing: 2 },
+        },
+        key3: {
+          value: 'value3',
+          expiration: -1,
+          metadata: { testing: 3 },
+        },
+      });
+      expect(await ns.list()).toEqual({
+        keys: [
+          { name: 'key1', metadata: { testing: 1 } },
+          { name: 'key2', metadata: { testing: 2 } },
+          { name: 'key3', metadata: { testing: 3 } },
+        ],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+
+    test('it lists keys with expiration', async () => {
+      KVNamespace.getTimestamp = () => 500;
+      const [ns] = createNamespace({
+        key1: {
+          value: 'value1',
+          expiration: 1000,
+          metadata: null,
+        },
+        key2: {
+          value: 'value2',
+          expiration: 2000,
+          metadata: null,
+        },
+        key3: {
+          value: 'value3',
+          expiration: 3000,
+          metadata: null,
+        },
+      });
+      expect(await ns.list()).toEqual({
+        keys: [
+          { name: 'key1', expiration: 1000 },
+          { name: 'key2', expiration: 2000 },
+          { name: 'key3', expiration: 3000 },
+        ],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+
+    test('it lists keys with metadata and expiration', async () => {
+      KVNamespace.getTimestamp = () => 500;
+      const [ns] = createNamespace({
+        key1: {
+          value: 'value1',
+          expiration: 1000,
+          metadata: { testing: 1 },
+        },
+        key2: {
+          value: 'value2',
+          expiration: 2000,
+          metadata: { testing: 2 },
+        },
+        key3: {
+          value: 'value3',
+          expiration: 3000,
+          metadata: { testing: 3 },
+        },
+      });
+      expect(await ns.list()).toEqual({
+        keys: [
+          { name: 'key1', expiration: 1000, metadata: { testing: 1 } },
+          { name: 'key2', expiration: 2000, metadata: { testing: 2 } },
+          { name: 'key3', expiration: 3000, metadata: { testing: 3 } },
+        ],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+
+    test('it ignores and removes expired keys', async () => {
+      const [ns] = createNamespace({
+        key1: {
+          value: 'value1',
+          expiration: 1000,
+          metadata: null,
+        },
+        key2: {
+          value: 'value2',
+          expiration: 2000,
+          metadata: null,
+        },
+        key3: {
+          value: 'value3',
+          expiration: 3000,
+          metadata: null,
+        },
+      });
+      expect(await ns.list()).toEqual({
+        keys: [],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+
+    test('it paginates keys', async () => {
+      const [ns] = createNamespace({
+        key1: {
+          value: 'value1',
+          expiration: -1,
+          metadata: null,
+        },
+        key2: {
+          value: 'value2',
+          expiration: -1,
+          metadata: null,
+        },
+        key3: {
+          value: 'value3',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      const { keys, list_complete, cursor } = await ns.list({ limit: 2 });
+      expect({ keys, list_complete }).toEqual({
+        keys: [{ name: 'key1' }, { name: 'key2' }],
+        list_complete: false,
+      });
+      expect(cursor).not.toBe('');
+      expect(await ns.list({ limit: 2, cursor })).toEqual({
+        keys: [{ name: 'key3' }],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+
+    test('it paginates keys matching prefix', async () => {
+      const [ns] = createNamespace({
+        section1key1: {
+          value: 'value11',
+          expiration: -1,
+          metadata: null,
+        },
+        section1key2: {
+          value: 'value12',
+          expiration: -1,
+          metadata: null,
+        },
+        section1key3: {
+          value: 'value13',
+          expiration: -1,
+          metadata: null,
+        },
+        section2key1: {
+          value: 'value21',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      const { keys, list_complete, cursor } = await ns.list({ prefix: 'section1', limit: 2 });
+      expect({ keys, list_complete }).toEqual({
+        keys: [{ name: 'section1key1' }, { name: 'section1key2' }],
+        list_complete: false,
+      });
+      expect(cursor).not.toBe('');
+      expect(await ns.list({ prefix: 'section1', limit: 2, cursor })).toEqual({
+        keys: [{ name: 'section1key3' }],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+
+    test('it returns an empty list with no keys', async () => {
+      const [ns] = createNamespace();
+      expect(await ns.list()).toEqual({
+        keys: [],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+
+    test('it returns an empty list with no matching keys', async () => {
+      const [ns] = createNamespace({
+        key1: {
+          value: 'value1',
+          expiration: -1,
+          metadata: null,
+        },
+        key2: {
+          value: 'value2',
+          expiration: -1,
+          metadata: null,
+        },
+        key3: {
+          value: 'value3',
+          expiration: -1,
+          metadata: null,
+        },
+      });
+      expect(await ns.list({ prefix: 'none' })).toEqual({
+        keys: [],
+        list_complete: true,
+        cursor: '',
+      });
+    });
+  });
+});

--- a/app/__tests__/kv-namespace_spec.js
+++ b/app/__tests__/kv-namespace_spec.js
@@ -1,13 +1,41 @@
+const path = require("path");
+const { promisify } = require('util');
+const rimraf = promisify(require("rimraf"));
 const { KVNamespace } = require('../kv-namespace');
 const { InMemoryKVStore } = require('../in-memory-kv-store');
+const { FileKVStore } = require('../file-kv-store');
 
 const TEST_NAMESPACE = 'TEST_NAMESPACE';
+const TEST_NAMESPACE_PATH = path.join(__dirname, TEST_NAMESPACE);
 
-function createNamespace(initialData) {
+async function createMemoryNamespace(initialData) {
   const store = new InMemoryKVStore();
   store.values[TEST_NAMESPACE] = initialData || {};
-  return [store.getClient(TEST_NAMESPACE), store];
+  return {
+    ns: store.getClient(TEST_NAMESPACE),
+    storedFor: async (key) => store.values[TEST_NAMESPACE][key],
+  };
 }
+
+async function createFileNamespace(initialData) {
+  await rimraf(TEST_NAMESPACE_PATH);
+  const store = new FileKVStore(__dirname);
+  for(const [key, data] of Object.entries(initialData || {})) {
+    await FileKVStore.putter(path.join(TEST_NAMESPACE_PATH, key), data);
+  }
+  return {
+    ns: store.getClient(TEST_NAMESPACE),
+    storedFor: async (key) => {
+      const stored = await FileKVStore.getter(path.join(TEST_NAMESPACE_PATH, key));
+      return stored === null ? undefined : stored;
+    },
+  };
+}
+
+const namespaceCreators = {
+  memory: createMemoryNamespace,
+  file: createFileNamespace,
+};
 
 describe('kv-namespace', () => {
   beforeEach(() => {
@@ -15,585 +43,606 @@ describe('kv-namespace', () => {
     KVNamespace.getTimestamp = () => 5000;
   });
 
-  describe('get', () => {
-    test('it gets text by default', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: 'value',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      expect(await ns.get('key')).toBe('value');
-    });
-
-    test('it gets text', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: 'value',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      expect(await ns.get('key', 'text')).toBe('value');
-    });
-
-    test('it gets json', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: '{"field": "value"}',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      expect(await ns.get('key', 'json')).toStrictEqual({ field: 'value' });
-    });
-
-    test('it gets array buffers', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: '\x01\x02\x03',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      expect(new Uint8Array(await ns.get('key', 'arrayBuffer'))).toStrictEqual(new Uint8Array([1, 2, 3]));
-    });
-
-    test('it fails to get streams', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: '\x01\x02\x03',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      expect.assertions(1);
-      await expect(ns.get('key', 'stream')).rejects.toStrictEqual(new Error('Type "stream" is not supported!'));
-    });
-
-    test('it returns null for non-existent keys', async () => {
-      const [ns] = createNamespace();
-      await expect(await ns.get('key')).toBeNull();
-    });
-
-    test('it returns null for and removes expired keys', async () => {
-      const [ns, store] = createNamespace({
-        key: {
-          value: 'value',
-          expiration: 1000,
-          metadata: null,
-        },
-      });
-      await expect(store.values[TEST_NAMESPACE].key).toBeDefined();
-      await expect(await ns.get('key')).toBeNull();
-      await expect(store.values[TEST_NAMESPACE].key).toBeUndefined();
-    });
+  afterAll(async () => {
+    // Delete files created during tests at the end
+    await rimraf(TEST_NAMESPACE_PATH);
   });
 
-  describe('getWithMetadata', () => {
-    test('it gets text by default with metadata', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: 'value',
-          expiration: -1,
-          metadata: { testing: true },
-        },
-      });
-      expect(await ns.getWithMetadata('key')).toStrictEqual({
-        value: 'value',
-        metadata: { testing: true },
-      });
-    });
+  for (const [namespaceType, createNamespace] of Object.entries(namespaceCreators)) {
+    describe(namespaceType, () => {
+      describe('get', () => {
+        test('it gets text by default', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: 'value',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          expect(await ns.get('key')).toBe('value');
+        });
 
-    test('it gets text with metadata', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: 'value',
-          expiration: -1,
-          metadata: { testing: true },
-        },
-      });
-      expect(await ns.getWithMetadata('key', 'text')).toStrictEqual({
-        value: 'value',
-        metadata: { testing: true },
-      });
-    });
+        test('it gets text', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: 'value',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          expect(await ns.get('key', 'text')).toBe('value');
+        });
 
-    test('it gets json with metadata', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: '{"field": "value"}',
-          expiration: -1,
-          metadata: { testing: true },
-        },
-      });
-      expect(await ns.getWithMetadata('key', 'json')).toStrictEqual({
-        value: { field: 'value' },
-        metadata: { testing: true },
-      });
-    });
+        test('it gets json', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: '{"field": "value"}',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          expect(await ns.get('key', 'json')).toStrictEqual({ field: 'value' });
+        });
 
-    test('it gets array buffers with metadata', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: '\x01\x02\x03',
-          expiration: -1,
-          metadata: { testing: true },
-        },
-      });
-      const { value, metadata } = await ns.getWithMetadata('key', 'arrayBuffer');
-      expect({
-        value: new Uint8Array(value),
-        metadata,
-      }).toStrictEqual({
-        value: new Uint8Array([1, 2, 3]),
-        metadata: { testing: true },
-      });
-    });
+        test('it gets array buffers', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: '\x01\x02\x03',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          expect(new Uint8Array(await ns.get('key', 'arrayBuffer'))).toStrictEqual(new Uint8Array([1, 2, 3]));
+        });
 
-    test('it fails to get streams with metadata', async () => {
-      const [ns] = createNamespace({
-        key: {
-          value: '\x01\x02\x03',
-          expiration: -1,
-          metadata: { testing: true },
-        },
-      });
-      expect.assertions(1);
-      await expect(ns.getWithMetadata('key', 'stream')).rejects.toStrictEqual(
-        new Error('Type "stream" is not supported!')
-      );
-    });
+        test('it fails to get streams', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: '\x01\x02\x03',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          expect.assertions(1);
+          await expect(ns.get('key', 'stream')).rejects.toStrictEqual(new Error('Type "stream" is not supported!'));
+        });
 
-    test('it returns null for non-existent keys with metadata', async () => {
-      const [ns] = createNamespace();
-      await expect(await ns.getWithMetadata('key')).toStrictEqual({
-        value: null,
-        metadata: null,
-      });
-    });
+        test('it returns null for non-existent keys', async () => {
+          const { ns } = await createNamespace();
+          await expect(await ns.get('key')).toBeNull();
+        });
 
-    test('it returns null for and removes expired keys with metadata', async () => {
-      const [ns, store] = createNamespace({
-        key: {
-          value: 'value',
-          expiration: 1000,
-          metadata: { testing: true },
-        },
+        test('it returns null for and removes expired keys', async () => {
+          const { ns, storedFor } = await createNamespace({
+            key: {
+              value: 'value',
+              expiration: 1000,
+              metadata: null,
+            },
+          });
+          await expect(await storedFor('key')).toBeDefined();
+          await expect(await ns.get('key')).toBeNull();
+          await expect(await storedFor('key')).toBeUndefined();
+        });
       });
-      await expect(store.values[TEST_NAMESPACE].key).toBeDefined();
-      await expect(await ns.getWithMetadata('key')).toStrictEqual({
-        value: null,
-        metadata: null,
-      });
-      await expect(store.values[TEST_NAMESPACE].key).toBeUndefined();
-    });
-  });
 
-  describe('put', () => {
-    test('it puts text', async () => {
-      const [ns, store] = createNamespace();
-      await ns.put('key', 'value');
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: 'value',
-        expiration: -1,
-        metadata: null,
-      });
-    });
+      describe('getWithMetadata', () => {
+        test('it gets text by default with metadata', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: 'value',
+              expiration: -1,
+              metadata: { testing: true },
+            },
+          });
+          expect(await ns.getWithMetadata('key')).toStrictEqual({
+            value: 'value',
+            metadata: { testing: true },
+          });
+        });
 
-    test('it puts array buffers', async () => {
-      const [ns, store] = createNamespace();
-      await ns.put('key', new Uint8Array([1, 2, 3]).buffer);
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: '\x01\x02\x03',
-        expiration: -1,
-        metadata: null,
-      });
-    });
+        test('it gets text with metadata', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: 'value',
+              expiration: -1,
+              metadata: { testing: true },
+            },
+          });
+          expect(await ns.getWithMetadata('key', 'text')).toStrictEqual({
+            value: 'value',
+            metadata: { testing: true },
+          });
+        });
 
-    test('it puts text with expiration', async () => {
-      const [ns, store] = createNamespace();
-      await ns.put('key', 'value', { expiration: 1000 });
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: 'value',
-        expiration: 1000,
-        metadata: null,
-      });
-    });
+        test('it gets json with metadata', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: '{"field": "value"}',
+              expiration: -1,
+              metadata: { testing: true },
+            },
+          });
+          expect(await ns.getWithMetadata('key', 'json')).toStrictEqual({
+            value: { field: 'value' },
+            metadata: { testing: true },
+          });
+        });
 
-    test('it puts text with string expiration', async () => {
-      const [ns, store] = createNamespace();
-      await ns.put('key', 'value', { expiration: '1000' });
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: 'value',
-        expiration: 1000,
-        metadata: null,
-      });
-    });
+        test('it gets array buffers with metadata', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: '\x01\x02\x03',
+              expiration: -1,
+              metadata: { testing: true },
+            },
+          });
+          const { value, metadata } = await ns.getWithMetadata('key', 'arrayBuffer');
+          expect({
+            value: new Uint8Array(value),
+            metadata,
+          }).toStrictEqual({
+            value: new Uint8Array([1, 2, 3]),
+            metadata: { testing: true },
+          });
+        });
 
-    test('it puts text with expiration ttl', async () => {
-      KVNamespace.getTimestamp = () => 1000;
-      const [ns, store] = createNamespace();
-      await ns.put('key', 'value', { expirationTtl: 1000 });
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: 'value',
-        expiration: 2000,
-        metadata: null,
-      });
-    });
+        test('it fails to get streams with metadata', async () => {
+          const { ns } = await createNamespace({
+            key: {
+              value: '\x01\x02\x03',
+              expiration: -1,
+              metadata: { testing: true },
+            },
+          });
+          expect.assertions(1);
+          await expect(ns.getWithMetadata('key', 'stream')).rejects.toStrictEqual(
+            new Error('Type "stream" is not supported!')
+          );
+        });
 
-    test('it puts text with string expiration ttl', async () => {
-      KVNamespace.getTimestamp = () => 1000;
-      const [ns, store] = createNamespace();
-      await ns.put('key', 'value', { expirationTtl: '1000' });
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: 'value',
-        expiration: 2000,
-        metadata: null,
-      });
-    });
+        test('it returns null for non-existent keys with metadata', async () => {
+          const { ns } = await createNamespace();
+          await expect(await ns.getWithMetadata('key')).toStrictEqual({
+            value: null,
+            metadata: null,
+          });
+        });
 
-    test('it puts text with metadata', async () => {
-      const [ns, store] = createNamespace();
-      await ns.put('key', 'value', { metadata: { testing: true } });
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: 'value',
-        expiration: -1,
-        metadata: { testing: true },
+        test('it returns null for and removes expired keys with metadata', async () => {
+          const { ns, storedFor } = await createNamespace({
+            key: {
+              value: 'value',
+              expiration: 1000,
+              metadata: { testing: true },
+            },
+          });
+          await expect(await storedFor('key')).toBeDefined();
+          await expect(await ns.getWithMetadata('key')).toStrictEqual({
+            value: null,
+            metadata: null,
+          });
+          await expect(await storedFor('key')).toBeUndefined();
+        });
       });
-    });
 
-    test('it puts text with expiration and metadata', async () => {
-      const [ns, store] = createNamespace();
-      await ns.put('key', 'value', {
-        expiration: 1000,
-        metadata: { testing: true },
-      });
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: 'value',
-        expiration: 1000,
-        metadata: { testing: true },
-      });
-    });
+      describe('put', () => {
+        test('it puts text', async () => {
+          const { ns, storedFor } = await createNamespace();
+          await ns.put('key', 'value');
+          await expect(await storedFor('key')).toStrictEqual({
+            value: 'value',
+            expiration: -1,
+            metadata: null,
+          });
+        });
 
-    test('it puts text with expiration ttl and metadata', async () => {
-      KVNamespace.getTimestamp = () => 1000;
-      const [ns, store] = createNamespace();
-      await ns.put('key', 'value', {
-        expirationTtl: 1000,
-        metadata: { testing: true },
-      });
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: 'value',
-        expiration: 2000,
-        metadata: { testing: true },
-      });
-    });
+        test('it puts array buffers', async () => {
+          const { ns, storedFor } = await createNamespace();
+          await ns.put('key', new Uint8Array([1, 2, 3]).buffer);
+          await expect(await storedFor('key')).toStrictEqual({
+            value: '\x01\x02\x03',
+            expiration: -1,
+            metadata: null,
+          });
+        });
 
-    test('it overrides existing keys', async () => {
-      const [ns, store] = createNamespace({
-        key: {
-          value: 'value',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      await ns.put('key', 'value2', {
-        expiration: 1000,
-        metadata: { testing: true },
-      });
-      await expect(store.values[TEST_NAMESPACE].key).toStrictEqual({
-        value: 'value2',
-        expiration: 1000,
-        metadata: { testing: true },
-      });
-    });
-  });
+        test('it puts text with expiration', async () => {
+          const { ns, storedFor } = await createNamespace();
+          await ns.put('key', 'value', { expiration: 1000 });
+          await expect(await storedFor('key')).toStrictEqual({
+            value: 'value',
+            expiration: 1000,
+            metadata: null,
+          });
+        });
 
-  describe('delete', () => {
-    test('it deletes existing keys', async () => {
-      const [ns, store] = createNamespace({
-        key: {
-          value: 'value',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      await ns.delete('key');
-      await expect(store.values[TEST_NAMESPACE].key).toBeUndefined();
-    });
+        test('it puts text with string expiration', async () => {
+          const { ns, storedFor } = await createNamespace();
+          await ns.put('key', 'value', { expiration: '1000' });
+          await expect(await storedFor('key')).toStrictEqual({
+            value: 'value',
+            expiration: 1000,
+            metadata: null,
+          });
+        });
 
-    test('it does nothing for non-existent keys', async () => {
-      const [ns] = createNamespace({});
-      await ns.delete('key');
-    });
-  });
+        test('it puts text with expiration ttl', async () => {
+          KVNamespace.getTimestamp = () => 1000;
+          const { ns, storedFor } = await createNamespace();
+          await ns.put('key', 'value', { expirationTtl: 1000 });
+          await expect(await storedFor('key')).toStrictEqual({
+            value: 'value',
+            expiration: 2000,
+            metadata: null,
+          });
+        });
 
-  describe('list', () => {
-    test('it lists keys in sorted order', async () => {
-      const [ns] = createNamespace({
-        key3: {
-          value: 'value3',
-          expiration: -1,
-          metadata: null,
-        },
-        key1: {
-          value: 'value1',
-          expiration: -1,
-          metadata: null,
-        },
-        key2: {
-          value: 'value2',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      expect(await ns.list()).toEqual({
-        keys: [{ name: 'key1' }, { name: 'key2' }, { name: 'key3' }],
-        list_complete: true,
-        cursor: '',
-      });
-    });
+        test('it puts text with string expiration ttl', async () => {
+          KVNamespace.getTimestamp = () => 1000;
+          const { ns, storedFor } = await createNamespace();
+          await ns.put('key', 'value', { expirationTtl: '1000' });
+          await expect(await storedFor('key')).toStrictEqual({
+            value: 'value',
+            expiration: 2000,
+            metadata: null,
+          });
+        });
 
-    test('it lists keys matching prefix', async () => {
-      const [ns] = createNamespace({
-        section1key1: {
-          value: 'value11',
-          expiration: -1,
-          metadata: null,
-        },
-        section1key2: {
-          value: 'value12',
-          expiration: -1,
-          metadata: null,
-        },
-        section2key1: {
-          value: 'value21',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      expect(await ns.list({ prefix: 'section1' })).toEqual({
-        keys: [{ name: 'section1key1' }, { name: 'section1key2' }],
-        list_complete: true,
-        cursor: '',
-      });
-    });
+        test('it puts text with metadata', async () => {
+          const { ns, storedFor } = await createNamespace();
+          await ns.put('key', 'value', { metadata: { testing: true } });
+          await expect(await storedFor('key')).toStrictEqual({
+            value: 'value',
+            expiration: -1,
+            metadata: { testing: true },
+          });
+        });
 
-    test('it lists keys with metadata', async () => {
-      const [ns] = createNamespace({
-        key1: {
-          value: 'value1',
-          expiration: -1,
-          metadata: { testing: 1 },
-        },
-        key2: {
-          value: 'value2',
-          expiration: -1,
-          metadata: { testing: 2 },
-        },
-        key3: {
-          value: 'value3',
-          expiration: -1,
-          metadata: { testing: 3 },
-        },
-      });
-      expect(await ns.list()).toEqual({
-        keys: [
-          { name: 'key1', metadata: { testing: 1 } },
-          { name: 'key2', metadata: { testing: 2 } },
-          { name: 'key3', metadata: { testing: 3 } },
-        ],
-        list_complete: true,
-        cursor: '',
-      });
-    });
+        test('it puts text with expiration and metadata', async () => {
+          const { ns, storedFor } = await createNamespace();
+          await ns.put('key', 'value', {
+            expiration: 1000,
+            metadata: { testing: true },
+          });
+          await expect(await storedFor('key')).toStrictEqual({
+            value: 'value',
+            expiration: 1000,
+            metadata: { testing: true },
+          });
+        });
 
-    test('it lists keys with expiration', async () => {
-      KVNamespace.getTimestamp = () => 500;
-      const [ns] = createNamespace({
-        key1: {
-          value: 'value1',
-          expiration: 1000,
-          metadata: null,
-        },
-        key2: {
-          value: 'value2',
-          expiration: 2000,
-          metadata: null,
-        },
-        key3: {
-          value: 'value3',
-          expiration: 3000,
-          metadata: null,
-        },
-      });
-      expect(await ns.list()).toEqual({
-        keys: [
-          { name: 'key1', expiration: 1000 },
-          { name: 'key2', expiration: 2000 },
-          { name: 'key3', expiration: 3000 },
-        ],
-        list_complete: true,
-        cursor: '',
-      });
-    });
+        test('it puts text with expiration ttl and metadata', async () => {
+          KVNamespace.getTimestamp = () => 1000;
+          const { ns, storedFor } = await createNamespace();
+          await ns.put('key', 'value', {
+            expirationTtl: 1000,
+            metadata: { testing: true },
+          });
+          await expect(await storedFor('key')).toStrictEqual({
+            value: 'value',
+            expiration: 2000,
+            metadata: { testing: true },
+          });
+        });
 
-    test('it lists keys with metadata and expiration', async () => {
-      KVNamespace.getTimestamp = () => 500;
-      const [ns] = createNamespace({
-        key1: {
-          value: 'value1',
-          expiration: 1000,
-          metadata: { testing: 1 },
-        },
-        key2: {
-          value: 'value2',
-          expiration: 2000,
-          metadata: { testing: 2 },
-        },
-        key3: {
-          value: 'value3',
-          expiration: 3000,
-          metadata: { testing: 3 },
-        },
+        test('it overrides existing keys', async () => {
+          const { ns, storedFor } = await createNamespace({
+            key: {
+              value: 'value',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          await ns.put('key', 'value2', {
+            expiration: 1000,
+            metadata: { testing: true },
+          });
+          await expect(await storedFor('key')).toStrictEqual({
+            value: 'value2',
+            expiration: 1000,
+            metadata: { testing: true },
+          });
+        });
       });
-      expect(await ns.list()).toEqual({
-        keys: [
-          { name: 'key1', expiration: 1000, metadata: { testing: 1 } },
-          { name: 'key2', expiration: 2000, metadata: { testing: 2 } },
-          { name: 'key3', expiration: 3000, metadata: { testing: 3 } },
-        ],
-        list_complete: true,
-        cursor: '',
-      });
-    });
 
-    test('it ignores and removes expired keys', async () => {
-      const [ns] = createNamespace({
-        key1: {
-          value: 'value1',
-          expiration: 1000,
-          metadata: null,
-        },
-        key2: {
-          value: 'value2',
-          expiration: 2000,
-          metadata: null,
-        },
-        key3: {
-          value: 'value3',
-          expiration: 3000,
-          metadata: null,
-        },
-      });
-      expect(await ns.list()).toEqual({
-        keys: [],
-        list_complete: true,
-        cursor: '',
-      });
-    });
+      describe('delete', () => {
+        test('it deletes existing keys', async () => {
+          const { ns, storedFor } = await createNamespace({
+            key: {
+              value: 'value',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          await ns.delete('key');
+          await expect(await storedFor('key')).toBeUndefined();
+        });
 
-    test('it paginates keys', async () => {
-      const [ns] = createNamespace({
-        key1: {
-          value: 'value1',
-          expiration: -1,
-          metadata: null,
-        },
-        key2: {
-          value: 'value2',
-          expiration: -1,
-          metadata: null,
-        },
-        key3: {
-          value: 'value3',
-          expiration: -1,
-          metadata: null,
-        },
+        test('it does nothing for non-existent keys', async () => {
+          const { ns } = await createNamespace({});
+          await ns.delete('key');
+        });
       });
-      const { keys, list_complete, cursor } = await ns.list({ limit: 2 });
-      expect({ keys, list_complete }).toEqual({
-        keys: [{ name: 'key1' }, { name: 'key2' }],
-        list_complete: false,
-      });
-      expect(cursor).not.toBe('');
-      expect(await ns.list({ limit: 2, cursor })).toEqual({
-        keys: [{ name: 'key3' }],
-        list_complete: true,
-        cursor: '',
-      });
-    });
 
-    test('it paginates keys matching prefix', async () => {
-      const [ns] = createNamespace({
-        section1key1: {
-          value: 'value11',
-          expiration: -1,
-          metadata: null,
-        },
-        section1key2: {
-          value: 'value12',
-          expiration: -1,
-          metadata: null,
-        },
-        section1key3: {
-          value: 'value13',
-          expiration: -1,
-          metadata: null,
-        },
-        section2key1: {
-          value: 'value21',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      const { keys, list_complete, cursor } = await ns.list({ prefix: 'section1', limit: 2 });
-      expect({ keys, list_complete }).toEqual({
-        keys: [{ name: 'section1key1' }, { name: 'section1key2' }],
-        list_complete: false,
-      });
-      expect(cursor).not.toBe('');
-      expect(await ns.list({ prefix: 'section1', limit: 2, cursor })).toEqual({
-        keys: [{ name: 'section1key3' }],
-        list_complete: true,
-        cursor: '',
-      });
-    });
+      describe('list', () => {
+        test('it lists keys in sorted order', async () => {
+          const { ns } = await createNamespace({
+            key3: {
+              value: 'value3',
+              expiration: -1,
+              metadata: null,
+            },
+            key1: {
+              value: 'value1',
+              expiration: -1,
+              metadata: null,
+            },
+            key2: {
+              value: 'value2',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          expect(await ns.list()).toEqual({
+            keys: [{ name: 'key1' }, { name: 'key2' }, { name: 'key3' }],
+            list_complete: true,
+            cursor: '',
+          });
+        });
 
-    test('it returns an empty list with no keys', async () => {
-      const [ns] = createNamespace();
-      expect(await ns.list()).toEqual({
-        keys: [],
-        list_complete: true,
-        cursor: '',
-      });
-    });
+        test('it lists keys matching prefix', async () => {
+          const { ns } = await createNamespace({
+            section1key1: {
+              value: 'value11',
+              expiration: -1,
+              metadata: null,
+            },
+            section1key2: {
+              value: 'value12',
+              expiration: -1,
+              metadata: null,
+            },
+            section2key1: {
+              value: 'value21',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          expect(await ns.list({ prefix: 'section1' })).toEqual({
+            keys: [{ name: 'section1key1' }, { name: 'section1key2' }],
+            list_complete: true,
+            cursor: '',
+          });
+        });
 
-    test('it returns an empty list with no matching keys', async () => {
-      const [ns] = createNamespace({
-        key1: {
-          value: 'value1',
-          expiration: -1,
-          metadata: null,
-        },
-        key2: {
-          value: 'value2',
-          expiration: -1,
-          metadata: null,
-        },
-        key3: {
-          value: 'value3',
-          expiration: -1,
-          metadata: null,
-        },
-      });
-      expect(await ns.list({ prefix: 'none' })).toEqual({
-        keys: [],
-        list_complete: true,
-        cursor: '',
+        test('it lists keys with metadata', async () => {
+          const { ns } = await createNamespace({
+            key1: {
+              value: 'value1',
+              expiration: -1,
+              metadata: { testing: 1 },
+            },
+            key2: {
+              value: 'value2',
+              expiration: -1,
+              metadata: { testing: 2 },
+            },
+            key3: {
+              value: 'value3',
+              expiration: -1,
+              metadata: { testing: 3 },
+            },
+          });
+          expect(await ns.list()).toEqual({
+            keys: [
+              { name: 'key1', metadata: { testing: 1 } },
+              { name: 'key2', metadata: { testing: 2 } },
+              { name: 'key3', metadata: { testing: 3 } },
+            ],
+            list_complete: true,
+            cursor: '',
+          });
+        });
+
+        test('it lists keys with expiration', async () => {
+          KVNamespace.getTimestamp = () => 500;
+          const { ns } = await createNamespace({
+            key1: {
+              value: 'value1',
+              expiration: 1000,
+              metadata: null,
+            },
+            key2: {
+              value: 'value2',
+              expiration: 2000,
+              metadata: null,
+            },
+            key3: {
+              value: 'value3',
+              expiration: 3000,
+              metadata: null,
+            },
+          });
+          expect(await ns.list()).toEqual({
+            keys: [
+              { name: 'key1', expiration: 1000 },
+              { name: 'key2', expiration: 2000 },
+              { name: 'key3', expiration: 3000 },
+            ],
+            list_complete: true,
+            cursor: '',
+          });
+        });
+
+        test('it lists keys with metadata and expiration', async () => {
+          KVNamespace.getTimestamp = () => 500;
+          const { ns } = await createNamespace({
+            key1: {
+              value: 'value1',
+              expiration: 1000,
+              metadata: { testing: 1 },
+            },
+            key2: {
+              value: 'value2',
+              expiration: 2000,
+              metadata: { testing: 2 },
+            },
+            key3: {
+              value: 'value3',
+              expiration: 3000,
+              metadata: { testing: 3 },
+            },
+          });
+          expect(await ns.list()).toEqual({
+            keys: [
+              { name: 'key1', expiration: 1000, metadata: { testing: 1 } },
+              { name: 'key2', expiration: 2000, metadata: { testing: 2 } },
+              { name: 'key3', expiration: 3000, metadata: { testing: 3 } },
+            ],
+            list_complete: true,
+            cursor: '',
+          });
+        });
+
+        test('it ignores and removes expired keys', async () => {
+          const { ns, storedFor } = await createNamespace({
+            key1: {
+              value: 'value1',
+              expiration: 1000,
+              metadata: null,
+            },
+            key2: {
+              value: 'value2',
+              expiration: 2000,
+              metadata: null,
+            },
+            key3: {
+              value: 'value3',
+              expiration: 3000,
+              metadata: null,
+            },
+          });
+          expect(await storedFor('key1')).toBeDefined();
+          expect(await storedFor('key2')).toBeDefined();
+          expect(await storedFor('key3')).toBeDefined();
+          expect(await ns.list()).toEqual({
+            keys: [],
+            list_complete: true,
+            cursor: '',
+          });
+          expect(await storedFor('key1')).toBeUndefined();
+          expect(await storedFor('key2')).toBeUndefined();
+          expect(await storedFor('key3')).toBeUndefined();
+        });
+
+        test('it paginates keys', async () => {
+          const { ns } = await createNamespace({
+            key1: {
+              value: 'value1',
+              expiration: -1,
+              metadata: null,
+            },
+            key2: {
+              value: 'value2',
+              expiration: -1,
+              metadata: null,
+            },
+            key3: {
+              value: 'value3',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          const { keys, list_complete, cursor } = await ns.list({ limit: 2 });
+          expect({ keys, list_complete }).toEqual({
+            keys: [{ name: 'key1' }, { name: 'key2' }],
+            list_complete: false,
+          });
+          expect(cursor).not.toBe('');
+          expect(await ns.list({ limit: 2, cursor })).toEqual({
+            keys: [{ name: 'key3' }],
+            list_complete: true,
+            cursor: '',
+          });
+        });
+
+        test('it paginates keys matching prefix', async () => {
+          const { ns } = await createNamespace({
+            section1key1: {
+              value: 'value11',
+              expiration: -1,
+              metadata: null,
+            },
+            section1key2: {
+              value: 'value12',
+              expiration: -1,
+              metadata: null,
+            },
+            section1key3: {
+              value: 'value13',
+              expiration: -1,
+              metadata: null,
+            },
+            section2key1: {
+              value: 'value21',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          const { keys, list_complete, cursor } = await ns.list({ prefix: 'section1', limit: 2 });
+          expect({ keys, list_complete }).toEqual({
+            keys: [{ name: 'section1key1' }, { name: 'section1key2' }],
+            list_complete: false,
+          });
+          expect(cursor).not.toBe('');
+          expect(
+            await ns.list({
+              prefix: 'section1',
+              limit: 2,
+              cursor,
+            })
+          ).toEqual({
+            keys: [{ name: 'section1key3' }],
+            list_complete: true,
+            cursor: '',
+          });
+        });
+
+        test('it returns an empty list with no keys', async () => {
+          const { ns } = await createNamespace();
+          expect(await ns.list()).toEqual({
+            keys: [],
+            list_complete: true,
+            cursor: '',
+          });
+        });
+
+        test('it returns an empty list with no matching keys', async () => {
+          const { ns } = await createNamespace({
+            key1: {
+              value: 'value1',
+              expiration: -1,
+              metadata: null,
+            },
+            key2: {
+              value: 'value2',
+              expiration: -1,
+              metadata: null,
+            },
+            key3: {
+              value: 'value3',
+              expiration: -1,
+              metadata: null,
+            },
+          });
+          expect(await ns.list({ prefix: 'none' })).toEqual({
+            keys: [],
+            list_complete: true,
+            cursor: '',
+          });
+        });
       });
     });
-  });
+  }
 });

--- a/app/__tests__/worker_spec.js
+++ b/app/__tests__/worker_spec.js
@@ -221,7 +221,7 @@ describe("Workers", () => {
       expect(await response.text()).toBe("foo");
       expect(await kvStoreFactory.getClient("MYSTORE").get("foo")).toBe("bar");
       await kvStoreFactory.getClient("MYSTORE").delete("foo");
-      expect(await kvStoreFactory.getClient("MYSTORE").get("foo")).toBe(undefined);
+      expect(await kvStoreFactory.getClient("MYSTORE").get("foo")).toBe(null);
     });
 
     test("It can access CloudFlare 'environment variables' and 'secrets' ", async () => {

--- a/app/caches.js
+++ b/app/caches.js
@@ -1,0 +1,20 @@
+// Caches API stubs: see https://developers.cloudflare.com/workers/runtime-apis/cache
+// (required for Workers Sites to work)
+const caches = {
+  default: {
+    put(request, response) {
+      // undefined indicates the response for the request was "successfully" cached
+      return Promise.resolve(undefined);
+    },
+    match(request, options) {
+      // undefined indicates that a cached response for the request couldn't be found
+      return Promise.resolve(undefined);
+    },
+    delete(request, options) {
+      // false indicates that a cached response for the request couldn't be found to delete
+      return Promise.resolve(false);
+    }
+  }
+};
+
+module.exports = { caches };

--- a/app/file-kv-store.js
+++ b/app/file-kv-store.js
@@ -1,0 +1,169 @@
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const mkdirp = require('mkdirp');
+const { KVNamespace, allLister } = require('./kv-namespace');
+
+/** Reads a file's contents, returning null if the file couldn't be found */
+async function readFile(filePath) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filePath, 'utf8', (err, data) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          resolve(null); // File not found
+        } else {
+          reject(err);
+        }
+      } else {
+        resolve(data);
+      }
+    });
+  });
+}
+
+/** Writes data to a file */
+async function writeFile(filePath, data) {
+  await mkdirp(path.dirname(filePath));
+  return new Promise((resolve, reject) => {
+    fs.writeFile(filePath, data, 'utf8', (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/** Deletes a file, returning true if successful, or false if the file couldn't be found */
+async function deleteFile(filePath) {
+  return new Promise((resolve, reject) => {
+    fs.unlink(filePath, (err) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          resolve(false); // File not found
+        } else {
+          reject(err);
+        }
+      } else {
+        resolve(true);
+      }
+    });
+  });
+}
+
+/** Gets a list of all files in a directory, returning an empty array if the directory couldn't be found */
+async function readDir(filePath) {
+  return new Promise((resolve, reject) => {
+    fs.readdir(filePath,(err, files) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          resolve([]); // Directory not found
+        } else {
+          reject(err);
+        }
+      } else {
+        resolve(files);
+      }
+    });
+  });
+}
+
+const stat = promisify(fs.stat);
+
+/** Recursively traverses a directory and all its sub-directories, returning a list of relative file paths */
+async function walkDir(rootPath) {
+  const files = [];
+  const fileNames = await readDir(rootPath);
+  for (const fileName of fileNames) {
+    const filePath = path.join(rootPath, fileName);
+    const fileStat = await stat(filePath);
+    if (fileStat.isDirectory()) {
+      // Recurse into this subdirectory, adding all it's paths
+      files.push(...(await walkDir(filePath)));
+    } else {
+      files.push(filePath);
+    }
+  }
+  return files;
+}
+
+/** Suffix to add to key file names for the metadata file containing metadata and expiration information */
+const metaSuffix = '.meta.json';
+
+class FileKVStore {
+  constructor(root = ".") {
+    this.root = root;
+  }
+
+  static async getter(filePath) {
+    // Try to get file data
+    const value = await readFile(filePath);
+    // If it didn't exist, return null
+    if (value === null) return null;
+
+    // Try to get file metadata
+    const metadataValue = await readFile(filePath + metaSuffix);
+    if (metadataValue === null) {
+      // If it didn't exist, assume no expiration and metadata
+      return { value, expiration: -1, metadata: null };
+    } else {
+      // Otherwise, if it did, JSON parse it and use it
+      const { expiration, metadata } = JSON.parse(metadataValue);
+      return { value, expiration, metadata };
+    }
+  }
+
+  static async putter(filePath, { value, expiration, metadata }) {
+    // Write file value
+    await writeFile(filePath, value);
+
+    const metaPath = filePath + metaSuffix;
+    if (expiration !== -1 || metadata !== null) {
+      // Write file metadata (if there is any)
+      await writeFile(metaPath, JSON.stringify({ expiration, metadata }));
+    } else {
+      // Otherwise, delete any metadata from old writes
+      await deleteFile(metaPath);
+    }
+  }
+
+  static async remover(filePath) {
+    // Delete file and any metadata
+    await deleteFile(filePath);
+    await deleteFile(filePath + metaSuffix);
+  }
+
+  static async lister(root, prefix, limit, startAfter) {
+    const filePaths = await walkDir(root);
+    const files = [];
+    for (const filePath of filePaths) {
+      // Ignore meta files
+      if (filePath.endsWith(metaSuffix)) continue;
+      // Get key name by removing root directory + path separator
+      const name = filePath.substring(root.length + 1);
+      // Try to get file metadata
+      const metadataValue = await readFile(path.join(root, name + metaSuffix));
+      if (metadataValue === null) {
+        // If it didn't exist, assume no expiration and metadata
+        files.push([name, { expiration: -1, metadata: null }]);
+      } else {
+        // Otherwise, if it did, JSON parse it and use it
+        const { expiration, metadata } = JSON.parse(metadataValue);
+        files.push([name, { expiration, metadata }]);
+      }
+    }
+    return allLister(files, prefix, limit, startAfter);
+  }
+
+  getClient(namespace) {
+    return new KVNamespace({
+      getter: async (key) => FileKVStore.getter(path.join(this.root, namespace, key)),
+      putter: async (key, data) => FileKVStore.putter(path.join(this.root, namespace, key), data),
+      remover: async (key) => FileKVStore.remover(path.join(this.root, namespace, key)),
+      lister: async (prefix, limit, startAfter) => FileKVStore.lister(path.join(this.root, namespace), prefix, limit, startAfter),
+    });
+  }
+}
+
+module.exports = { FileKVStore };

--- a/app/in-memory-kv-store.js
+++ b/app/in-memory-kv-store.js
@@ -1,4 +1,4 @@
-const { KVNamespace } = require('./kv-namespace');
+const { KVNamespace, allLister } = require('./kv-namespace');
 
 class InMemoryKVStore {
   constructor() {
@@ -11,30 +11,8 @@ class InMemoryKVStore {
       getter: async (key) => this.values[namespace][key] || null,
       putter: async (key, value) => (this.values[namespace][key] = value),
       remover: async (key) => delete this.values[namespace][key],
-      lister: async (prefix, limit, startAfter) => {
-        // Get all matching keys, sorted
-        const all = Object.entries(this.values[namespace])
-          .filter(([key]) => key.startsWith(prefix))
-          .sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
-
-        // Find the correct part of the sorted array to return
-        let startIndex = 0,
-          endIndex = all.length;
-        if (startAfter !== '') {
-          startIndex = all.findIndex(([key]) => key === startAfter);
-          // If we couldn't find where to start, return nothing
-          if (startIndex === -1) return { keys: [], next: '' };
-          // Since we want to start AFTER this index, add 1 to it
-          startIndex++;
-        }
-        endIndex = startIndex + limit;
-
-        // Return the keys and the next key if there is one
-        return {
-          keys: all.slice(startIndex, endIndex),
-          next: endIndex < all.length ? all[endIndex - 1][0] : '',
-        };
-      },
+      lister: async (prefix, limit, startAfter) =>
+        allLister(Object.entries(this.values[namespace]), prefix, limit, startAfter),
     });
   }
 }

--- a/app/in-memory-kv-store.js
+++ b/app/in-memory-kv-store.js
@@ -1,3 +1,5 @@
+const { KVNamespace } = require('./kv-namespace');
+
 class InMemoryKVStore {
   constructor() {
     this.values = {};
@@ -5,11 +7,35 @@ class InMemoryKVStore {
 
   getClient(namespace) {
     this.values[namespace] = this.values[namespace] || {};
-    return {
-      get: async key => this.values[namespace][key],
-      put: async (key, value) => (this.values[namespace][key] = value),
-      delete: async key => delete this.values[namespace][key]
-    };
+    return new KVNamespace({
+      getter: async (key) => this.values[namespace][key] || null,
+      putter: async (key, value) => (this.values[namespace][key] = value),
+      remover: async (key) => delete this.values[namespace][key],
+      lister: async (prefix, limit, startAfter) => {
+        // Get all matching keys, sorted
+        const all = Object.entries(this.values[namespace])
+          .filter(([key]) => key.startsWith(prefix))
+          .sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+
+        // Find the correct part of the sorted array to return
+        let startIndex = 0,
+          endIndex = all.length;
+        if (startAfter !== '') {
+          startIndex = all.findIndex(([key]) => key === startAfter);
+          // If we couldn't find where to start, return nothing
+          if (startIndex === -1) return { keys: [], next: '' };
+          // Since we want to start AFTER this index, add 1 to it
+          startIndex++;
+        }
+        endIndex = startIndex + limit;
+
+        // Return the keys and the next key if there is one
+        return {
+          keys: all.slice(startIndex, endIndex),
+          next: endIndex < all.length ? all[endIndex - 1][0] : '',
+        };
+      },
+    });
   }
 }
 

--- a/app/kv-namespace.js
+++ b/app/kv-namespace.js
@@ -1,0 +1,184 @@
+const { TextDecoder, TextEncoder } = require('util');
+
+/**
+ * @typedef {Object} KVValue
+ * @property {string} value
+ * @property {number} expiration
+ * @property {(* | null)} metadata
+ */
+
+/**
+ * @typedef {Object} KVNamespaceOptions
+ * @property {function(key: string): Promise<KVValue | null>} getter
+ * @property {function(key: string, value: KVValue): Promise<void>} putter
+ * @property {function(key: string): Promise<void>} remover
+ * @property {function(prefix: string, limit: number, startAfter: string): Promise<{keys: (string | KVValue)[][], next: string}>} lister
+ */
+
+class KVNamespace {
+  /**
+   * @returns {number} seconds since the UNIX epoch
+   */
+  static getTimestamp() {
+    return Math.round(Date.now() / 1000);
+  }
+
+  /**
+   * @param {(string | number | undefined)} value
+   * @returns {number} value as an integer, or -1 if it isn't one
+   * @private
+   */
+  static _normaliseInteger(value) {
+    if (typeof value === 'number') {
+      return Math.round(value);
+    } else if (typeof value === 'string') {
+      const parsed = parseInt(value);
+      return isNaN(parsed) ? -1 : parsed;
+    } else {
+      return -1;
+    }
+  }
+
+  /**
+   * @param {KVNamespaceOptions} options
+   */
+  constructor(options) {
+    const { getter, putter, remover, lister } = options;
+    this.getter = getter;
+    this.putter = putter;
+    this.remover = remover;
+    this.lister = lister;
+  }
+
+  /**
+   * @param {string} key
+   * @param {("text" | "json" | "arrayBuffer" | "stream")} [type]
+   * @returns {Promise<* | null>}
+   */
+  async get(key, type) {
+    return (await this.getWithMetadata(key, type)).value;
+  }
+
+  // TODO: support "stream" type
+  /**
+   * @param {string} key
+   * @param {("text" | "json" | "arrayBuffer" | "stream")} [type]
+   * @returns {Promise<{value: (* | null), metadata: (* | null)}>}
+   */
+  async getWithMetadata(key, type) {
+    // Get value (with metadata/expiration), if we couldn't find anything, return null
+    const fullValue = await this.getter(key);
+    if (fullValue === null) {
+      return { value: null, metadata: null };
+    }
+    // Extract out value, expiration and metadata
+    const { value, expiration, metadata } = fullValue;
+
+    // Check expiration, and delete key if expired
+    if (expiration !== -1 && expiration < KVNamespace.getTimestamp()) {
+      await this.delete(key);
+      return { value: null, metadata: null };
+    }
+
+    // Get correctly typed value, defaulting to text
+    let typedValue = value;
+    if (type === 'json') {
+      typedValue = JSON.parse(value);
+    } else if (type === 'arrayBuffer') {
+      typedValue = new TextEncoder().encode(value).buffer;
+    } else if (type === 'stream') {
+      throw new Error('Type "stream" is not supported!');
+    }
+
+    return { value: typedValue, metadata };
+  }
+
+  // TODO: support FormData and ReadableStream's as values
+  /**
+   * @param {string} key
+   * @param {(string | ArrayBuffer)} value
+   * @param {{expiration: (string | number | undefined), expirationTtl: (string | number | undefined), metadata: (* | undefined)}} [options]
+   * @returns {Promise<void>}
+   */
+  async put(key, value, options) {
+    options = options || {};
+
+    // Convert value to string if it isn't already
+    if (value instanceof ArrayBuffer) {
+      value = new TextDecoder().decode(value);
+    }
+
+    // Normalise expiration
+    let expiration = KVNamespace._normaliseInteger(options.expiration);
+    const expirationTtl = KVNamespace._normaliseInteger(options.expirationTtl);
+    if (expirationTtl !== -1) {
+      expiration = KVNamespace.getTimestamp() + expirationTtl;
+    }
+
+    // Normalise metadata
+    const metadata = options.metadata === undefined ? null : options.metadata;
+
+    // Store value, expiration and metadata
+    await this.putter(key, { value, expiration, metadata });
+  }
+
+  /**
+   * @param {string} key
+   * @returns {Promise<void>}
+   */
+  async delete(key) {
+    return this.remover(key);
+  }
+
+  /**
+   * @param {{prefix: (string | undefined), limit: (number | undefined), cursor: (string | undefined)}} [options]
+   * @returns {Promise<{keys: { name: string, expiration: (number | undefined), metadata: (* | undefined) }[], list_complete: boolean, cursor: string}>}
+   */
+  async list(options) {
+    // Get options
+    options = options || {};
+    const prefix = options.prefix || '';
+    const limit = options.limit === undefined ? 1000 : options.limit;
+    if (limit <= 0) {
+      throw new Error('Invalid limit: must be > 0');
+    }
+    const startAfter = options.cursor ? Buffer.from(options.cursor, 'base64').toString('utf8') : '';
+
+    // Get all keys
+    const { keys, next } = await this.lister(prefix, limit, startAfter);
+
+    // Get keys matching prefix
+    const timestamp = KVNamespace.getTimestamp();
+    const expiredKeys = [];
+    const filteredKeys = keys
+      .map(([name, fullValue]) => {
+        // Extract out value, expiration and metadata
+        const { expiration, metadata } = fullValue;
+        return {
+          name,
+          expiration: expiration === -1 ? undefined : expiration,
+          metadata: metadata == null ? undefined : metadata,
+        };
+      })
+      .filter(({ name, expiration }) => {
+        // Check timestamp
+        if (expiration !== undefined && expiration < timestamp) {
+          expiredKeys.push(name);
+          return false;
+        }
+        return true;
+      });
+
+    // Delete expired keys
+    for (const expiredKey of expiredKeys) {
+      await this.delete(expiredKey);
+    }
+
+    // Convert next to something that looks more cursor-like
+    const cursor = next === '' ? '' : Buffer.from(next, 'utf8').toString('base64');
+
+    return { keys: filteredKeys, list_complete: next === '', cursor };
+  }
+}
+
+module.exports = { KVNamespace };

--- a/app/kv-namespace.js
+++ b/app/kv-namespace.js
@@ -85,7 +85,15 @@ class KVNamespace {
     if (type === 'json') {
       typedValue = JSON.parse(value);
     } else if (type === 'arrayBuffer') {
-      typedValue = new TextEncoder().encode(value).buffer;
+      const buffer = new TextEncoder().encode(value).buffer;
+      // The API expects an ArrayBuffer to be returned, but Workers Sites expects there to be a length property (equal
+      // to the number of bytes in the buffer) which doesn't exist by default on ArrayBuffers. So we add a read-only
+      // length property equal to the byteLength.
+      Object.defineProperty(buffer, 'length', {
+        value: buffer.byteLength,
+        writable: false,
+      });
+      typedValue = buffer;
     } else if (type === 'stream') {
       throw new Error('Type "stream" is not supported!');
     }

--- a/app/minio-kv-store.js
+++ b/app/minio-kv-store.js
@@ -1,4 +1,5 @@
 const Minio = require('minio');
+const { KVNamespace } = require('./kv-namespace');
 
 class MinioKVStore {
   constructor(client) {
@@ -7,28 +8,90 @@ class MinioKVStore {
   }
 
   getClient(namespace) {
+    // Make sure the namespace is a valid bucket name
+    namespace = namespace.trim().toLowerCase().replace(/_/g, '-').toString();
     const bucketPromise = (async () => {
-      if (!await this.client.bucketExists(namespace))
-        await this.client.makeBucket(namespace);
+      if (!(await this.client.bucketExists(namespace))) await this.client.makeBucket(namespace);
     })();
-    return {
-      get: async key => {
+
+    return new KVNamespace({
+      getter: async (key) => {
         await bucketPromise;
-        return await new Promise((resolve, reject) => {
-          let data = ''
-          this.client.getObject(namespace, key, (event, stream) => {
-            stream.on('data', chunk => {
-              data = `${data}${chunk.toString('utf8')}`
-            })
-            stream.on('error', reject)
-            stream.on('end', () => resolve(data))
+        return new Promise(async (resolve, reject) => {
+          try {
+            // Get expiration and metadata
+            const stat = await this.client.statObject(namespace, key);
+            let expiration = parseInt(stat.metaData.expiration);
+            if (isNaN(expiration)) expiration = -1;
+            const metadata = JSON.parse(stat.metaData.metadata);
+
+            // Get value
+            let value = '';
+            const stream = await this.client.getObject(namespace, key);
+            stream.on('data', (chunk) => (value += chunk.toString('utf8')));
+            stream.on('error', reject);
+            stream.on('end', () => resolve({ value, expiration, metadata }));
+          } catch (e) {
+            if (e.code === 'NotFound' || e.code === 'NoSuchKey') {
+              resolve(null);
+            } else {
+              reject(e);
+            }
           }
-          )
-        })
+        });
       },
-      put: async (key, value) => { await bucketPromise; return this.client.putObject(namespace, key, JSON.stringify(value)) },
-      delete: async key => { await bucketPromise; return this.client.removeObject(namespace, key) }
-    };
+      putter: async (key, { value, expiration, metadata }) => {
+        await bucketPromise;
+        return this.client.putObject(namespace, key, value, undefined, {
+          // Minio metadata values need to be strings
+          expiration: expiration.toString(),
+          metadata: JSON.stringify(metadata),
+        });
+      },
+      remover: async (key) => {
+        await bucketPromise;
+        return this.client.removeObject(namespace, key);
+      },
+      lister: async (prefix, limit, start) => {
+        await bucketPromise;
+        return new Promise(async (resolve, reject) => {
+          // The `true` here enables recursive mode, ensuring keys containing '/' are returned
+          const stream = await this.client.extensions.listObjectsV2WithMetadata(namespace, prefix, true, start);
+          const objects = [];
+          let next = '';
+          stream.on('data', (object) => {
+            if (objects.length >= limit) {
+              // If this pushes us over the limit, set next and stop reading more objects
+              if (next === '') {
+                next = objects[objects.length - 1][0];
+                stream.destroy();
+              }
+              return;
+            }
+
+            // Default metadata
+            const value = { expiration: -1, metadata: null };
+            if (object.metadata) {
+              // listObjectsV2WithMetadata returns metadata in HTTP header format.
+              // Custom headers are prefixed with "X-Amz-Meta-".
+              // Each header key maps to an array, which will always be length 1 for us.
+              if (object.metadata['X-Amz-Meta-Expiration']) {
+                const expiration = parseInt(object.metadata['X-Amz-Meta-Expiration'][0]);
+                if (!isNaN(expiration)) value.expiration = expiration;
+              }
+              if (object.metadata['X-Amz-Meta-Metadata']) {
+                value.metadata = JSON.parse(object.metadata['X-Amz-Meta-Metadata'][0]);
+              }
+            }
+            // Add object in the form [key, { expiration, metadata }]
+            objects.push([object.name, value]);
+          });
+          stream.on('error', reject);
+          // Once all objects have been processed, resolve with the array
+          stream.on('end', () => resolve({ keys: objects, next }));
+        });
+      },
+    });
   }
 }
 

--- a/app/worker.js
+++ b/app/worker.js
@@ -6,6 +6,7 @@ const atob = require("atob");
 const btoa = require("btoa");
 const crypto = new (require("node-webcrypto-ossl"))();
 const { TextDecoder, TextEncoder } = require("util");
+const { caches } = require("./caches");
 
 function chomp(str) {
   return str.substr(0, str.length - 1);
@@ -104,6 +105,8 @@ class Worker {
       clearTimeout,
       clearInterval,
 
+      // Cache stubs
+      caches
     };
     const script = new Script(workerContents);
     script.runInContext(

--- a/package-lock.json
+++ b/package-lock.json
@@ -3790,6 +3790,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -3903,6 +3912,17 @@
                 "rimraf": "^2.5.4",
                 "slash": "^2.0.0",
                 "strip-ansi": "^5.0.0"
+              },
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.7.1",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                  "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                  "dev": true,
+                  "requires": {
+                    "glob": "^7.1.3"
+                  }
+                }
               }
             },
             "@jest/test-result": {
@@ -3985,6 +4005,17 @@
                 "mkdirp": "^0.5.1",
                 "slash": "^2.0.0",
                 "source-map": "^0.6.0"
+              },
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.5",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+                  "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "^1.2.5"
+                  }
+                }
               }
             },
             "jest-validate": {
@@ -4061,6 +4092,12 @@
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
           }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "p-limit": {
           "version": "2.2.2",
@@ -4631,6 +4668,23 @@
         "mkdirp": "^0.5.1",
         "strip-ansi": "^4.0.0",
         "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "jest-leak-detector": {
@@ -5113,6 +5167,21 @@
           "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
           "dev": true
         },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "pretty-format": {
           "version": "24.9.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
@@ -5171,6 +5240,21 @@
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
           }
         }
       }
@@ -5737,7 +5821,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -5774,6 +5859,21 @@
           "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
           "optional": true
         },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "optional": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "through2": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
@@ -5807,12 +5907,9 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "modify-values": {
       "version": "1.0.1",
@@ -5915,6 +6012,19 @@
         "webcrypto-core": "^0.1.26"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "nan": {
           "version": "2.14.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
@@ -6659,9 +6769,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express": "^4.16.4",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",
+    "mkdirp": "^1.0.4",
     "node-fetch": "^2.3.0",
     "node-webcrypto-ossl": "^1.0.48"
   },
@@ -35,6 +36,7 @@
   "devDependencies": {
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",
+    "rimraf": "^3.0.2",
     "standard-version": "^4.4.0",
     "supertest": "^3.3.0"
   },

--- a/start.js
+++ b/start.js
@@ -34,7 +34,8 @@ if (cluster.isMaster) {
 } else {
   const { createApp } = require(".");
   const port = process.argv[4];
-  let kvStores = (process.env.KV_NAMESPACES || "").split(",");
+  // .split(",") will return [""] when KV_NAMESPACES isn't set, so filter out empty strings
+  let kvStores = (process.env.KV_NAMESPACES || "").split(",").filter(name => name !== "");
   let env = {};
   if (process.argv[5]) {
     // Import config from provided wrangler.toml

--- a/start.js
+++ b/start.js
@@ -16,6 +16,9 @@ if (process.env.MINIO_ENDPOINT) {
   const { MinioKVStore, Minio, getEnvOpts } = require('./app/minio-kv-store');
   kvStore = ()=>new MinioKVStore(new Minio.Client(getEnvOpts(process.env)));
 }
+if (process.env.KV_FILE_ROOT) {
+  kvStore = ()=>new FileKVStore(process.env.KV_FILE_ROOT);
+}
 
 if (cluster.isMaster) {
   for (var i = 0; i < (process.env.NUM_WORKERS || 1); i++) {


### PR DESCRIPTION
### Remaining KV Functions

Implements the rest of the KV API on this page (aside from ReadableStream and FormData support): https://developers.cloudflare.com/workers/runtime-apis/kv according to the types here: https://github.com/cloudflare/workers-types/blob/ef285d752c6dc2af7af22c6b46b2acc7780649a5/index.d.ts#L582

- `get` now supports the `type` parameter (this can be `"text"` (default), `"json"` or `"arrayBuffer"`)
- Added `getWithMetadata` function
- Added optional `metadata`, `expiration` and `expirationTtl` to `put`
- Added `list` function, with pagination
- Getting the value of a non-existent key now returns `null` not `undefined`

### File-System KV Store

To implement Workers Sites, I needed to have a KV namespace that could get its values from the file-system. I also thought this could be a simpler way of persisting KV data between runs (than setting up a Minio server), so I added support for write & list KV operations too.

This can be enabled in a similar way to Minio, by specifying an environment variable `KV_FILE_ROOT` for the root directory. Each namespace gets its own folder, and each key gets its own file in this. Metadata and expiration information (if set) is stored in a `.meta.json` file with the same name as the key. This is so getting a key is exactly the same as reading from a file (for Workers Sites).

### Cache API Stubs

To implement Workers Sites, the `caches` API (as described here: https://developers.cloudflare.com/workers/runtime-apis/cache) needed to be in the worker scope, so I wrote some stubs that don't actually cache anything.

### Workers Sites Support

If a wrangler.toml file containing a `[site]` section with a `bucket` directory is loaded, the Workers Sites default KV namespace (`__STATIC_CONTENT`) and manifest (`__STATIC_CONTENT_MANIFEST`) will be added to the worker's scope.
`__STATIC_CONTENT` will be an instance of a File-System KV store pointing to `bucket`, so calls to `getAssetFromKV` from [@cloudflare/kv-asset-handler](https://github.com/cloudflare/kv-asset-handler) will always return the latest version of an asset in the bucket directory.

### New Dependencies

- [`mkdirp`](https://www.npmjs.com/package/mkdirp): for creating missing folders when putting values in the File-System KV store
- [`rimraf`](https://www.npmjs.com/package/rimraf): for resetting the local KV store folder when testing the File-System KV store

### Misc Fixes

- Make sure Minio bucket names are valid by converting them to lower-case and replacing underscores with dashes
- If the `KV_NAMESPACES` environment variable wasn't set, `kvStores` would be `[""]` not `[]` which causes an issue when using Minio, since bucket names can't be empty

Sorry this is such a big PR, got a bit carried away 😆 (about half of the additions are tests for KV though)