### PR TITLE
feat: Web Streams Support

### DIFF
--- a/app/__tests__/server_spec.js
+++ b/app/__tests__/server_spec.js
@@ -107,6 +107,7 @@ describe("server", () => {
       .send(body)
       .expect(200, 'POST');
   });
+
   it("can init a minio client", async () => {
     const app = createApp(
       'addEventListener("fetch", (e) => e.respondWith(new Response("success")))',
@@ -115,5 +116,19 @@ describe("server", () => {
         kvStores: [] // leave this empty so the client doesn't attempt to make requests
       }
     );
-  })
+  });
+
+  it("returns headers with multiple values", async () => {
+    const app = createApp(`addEventListener("fetch", (e) => {
+      const headers = new Headers();
+      headers.append("Some-Header", "value1");
+      headers.append("Some-Header", "value2");
+      e.respondWith(new Response("hello", {status: 201, headers: headers}));
+    })`);
+
+    await supertest(app)
+      .get("/some-route")
+      .expect(201, "hello")
+      .expect("Some-Header", "value1, value2");
+  });
 });

--- a/app/__tests__/worker_spec.js
+++ b/app/__tests__/worker_spec.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const { Worker } = require("../worker");
 const { InMemoryKVStore } = require("../in-memory-kv-store");
-const { Headers } = require("node-fetch");
+const { Headers } = require("@titelmedia/node-fetch");
 
 describe("Workers", () => {
   test("It Can Create and Execute a Listener", () => {
@@ -101,6 +101,13 @@ describe("Workers", () => {
     const response = await worker.executeFetchEvent("http://foo.com");
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("hello");
+  });
+
+  test("It can return a redirect response", async () => {
+    const worker = new Worker("foo.com", 'addEventListener("fetch", (e) => e.respondWith(Response.redirect("http://bar.com", 302)))');
+    const response = await worker.executeFetchEvent("http://foo.com");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("http://bar.com");
   });
 
   describe("Cloudflare Headers", () => {

--- a/app/kv-namespace.js
+++ b/app/kv-namespace.js
@@ -137,7 +137,6 @@ class KVNamespace {
     return { value: typedValue, metadata };
   }
 
-  // TODO: support FormData as value
   /**
    * @param {string} key
    * @param {(string | ReadableStream | ArrayBuffer)} value

--- a/app/server.js
+++ b/app/server.js
@@ -15,8 +15,11 @@ async function callWorker(worker, req, res) {
   const data = await response.arrayBuffer();
 
   res.status(response.status);
-  for (var pair of response.headers) {
-    res.set(pair[0], pair[1]);
+  for (const keyValues of Object.entries(response.headers.raw())) {
+    const key = keyValues[0];
+    // If there's just one value, use it, otherwise, use the the values array
+    const value = keyValues[1].length === 1 ? keyValues[1][0] : keyValues[1];
+    res.set(key, value);
   }
   res.end(Buffer.from(data), "binary");
 }

--- a/app/worker.js
+++ b/app/worker.js
@@ -1,12 +1,28 @@
 const { createContext, Script } = require("vm");
-const { Request, Response, Headers } = require("node-fetch");
+// The titelmedia node-fetch fork uses Web Streams instead of NodeJS ones
+const { Request, Response, Headers } = require("@titelmedia/node-fetch");
 const { URL } = require("url");
-const fetch = require("node-fetch");
+const fetch = require("@titelmedia/node-fetch");
 const atob = require("atob");
 const btoa = require("btoa");
 const crypto = new (require("node-webcrypto-ossl"))();
 const { TextDecoder, TextEncoder } = require("util");
 const { caches } = require("./caches");
+const {
+  ByteLengthQueuingStrategy,
+  CountQueuingStrategy,
+  ReadableByteStreamController,
+  ReadableStream,
+  ReadableStreamBYOBReader,
+  ReadableStreamBYOBRequest,
+  ReadableStreamDefaultController,
+  ReadableStreamDefaultReader,
+  TransformStream,
+  TransformStreamDefaultController,
+  WritableStream,
+  WritableStreamDefaultController,
+  WritableStreamDefaultWriter,
+} = require("web-streams-polyfill");
 
 function chomp(str) {
   return str.substr(0, str.length - 1);
@@ -106,7 +122,22 @@ class Worker {
       clearInterval,
 
       // Cache stubs
-      caches
+      caches,
+
+      // Streams
+      ByteLengthQueuingStrategy,
+      CountQueuingStrategy,
+      ReadableByteStreamController,
+      ReadableStream,
+      ReadableStreamBYOBReader,
+      ReadableStreamBYOBRequest,
+      ReadableStreamDefaultController,
+      ReadableStreamDefaultReader,
+      TransformStream,
+      TransformStreamDefaultController,
+      WritableStream,
+      WritableStreamDefaultController,
+      WritableStreamDefaultWriter
     };
     const script = new Script(workerContents);
     script.runInContext(

--- a/package-lock.json
+++ b/package-lock.json
@@ -542,6 +542,21 @@
         "@types/yargs": "^12.0.9"
       }
     },
+    "@titelmedia/node-fetch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@titelmedia/node-fetch/-/node-fetch-3.1.1.tgz",
+      "integrity": "sha512-4Rrag5DjxSAzpL9MswXGBG6ZA9wEE9fEzQukyv1zJZTG+ff6dsm3tbzbYmNDxZXi7HwhPFJfxUZmvXsGCJK/ng==",
+      "requires": {
+        "web-streams-polyfill": "^2.1.1"
+      },
+      "dependencies": {
+        "web-streams-polyfill": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
+          "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg=="
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
@@ -5971,11 +5986,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8010,6 +8020,11 @@
       "requires": {
         "makeerror": "1.0.x"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.1.tgz",
+      "integrity": "sha512-M+EmTdszMWINywOZaqpZ6VIEDUmNpRaTOuizF0ZKPjSDC8paMRe/jBBwFv0Yeyn5WYnM5pMqMQa82vpaE+IJRw=="
     },
     "webcrypto-core": {
       "version": "0.1.26",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/gja/cloudflare-worker-local#readme",
   "dependencies": {
     "@iarna/toml": "^2.2.3",
+    "@titelmedia/node-fetch": "^3.1.1",
     "atob": "^2.1.2",
     "body-parser": "^1.18.3",
     "btoa": "^1.2.1",
@@ -27,8 +28,8 @@
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",
     "mkdirp": "^1.0.4",
-    "node-fetch": "^2.3.0",
-    "node-webcrypto-ossl": "^1.0.48"
+    "node-webcrypto-ossl": "^1.0.48",
+    "web-streams-polyfill": "^3.0.1"
   },
   "optionalDependencies": {
     "minio": "^7.0.15"


### PR DESCRIPTION
This PR adds Web Streams (provided by [`web-streams-polyfill`](https://www.npmjs.com/package/web-streams-polyfill)) to workers' scope and adds `ReadableStream`support to KV `get`, `getWithMetadata` and `put` functions.

It also switches to using the [`@titelmedia/node-fetch`](https://www.npmjs.com/package/@titelmedia/node-fetch) fork of `node-fetch` which uses Web Streams instead of NodeJS ones, allowing Web Streams to be used as response bodies. This also closes #39, as `Response.redirect` is implemented by this fork (without a default redirect status though, I've [opened a PR](https://github.com/titel-media/node-fetch/pull/3)).