### PR TITLE
Generate random rayId per request, better simulate cloudflare.

### DIFF
--- a/app/__tests__/worker_spec.js
+++ b/app/__tests__/worker_spec.js
@@ -110,7 +110,7 @@ describe("Workers", () => {
         'addEventListener("fetch", (e) => e.respondWith(new Response("hello", {headers: e.request.headers})))'
       );
       const response = await worker.executeFetchEvent("http://foo.com");
-      expect(response.headers.get("CF-Ray")).toBe("0000000000000000");
+      expect(response.headers.get("CF-Ray")).toHaveLength(16);
       expect(response.headers.get("CF-Visitor")).toBe('{"scheme":"http"}');
       expect(response.headers.get("CF-IPCountry")).toBe("DEV");
       expect(response.headers.get("CF-Connecting-IP")).toBe("127.0.0.1");

--- a/app/worker.js
+++ b/app/worker.js
@@ -13,7 +13,7 @@ function chomp(str) {
 }
 
 function buildRequest(url, opts) {
-  const { country = "DEV", ip = "127.0.0.1", ray = "0000000000000000", ...requestOpts } = opts;
+  const { country = "DEV", ip = "127.0.0.1", ray = `${Math.floor(1000000000000000 + Math.random() * 9000000000000000)}`, ...requestOpts } = opts;
   const request = new Request(url, { redirect: "manual", ...requestOpts });
   const headers = request.headers;
   const parsedURL = new URL(request.url);


### PR DESCRIPTION
Minor change to generate the rayId rather than have it fixed, better mimics cf.