### PR TITLE
await async response so that exception handling can take place

### DIFF
--- a/app/__tests__/worker_spec.js
+++ b/app/__tests__/worker_spec.js
@@ -238,7 +238,15 @@ describe("Workers", () => {
     test("It fetches directly from origin is passThroughOnException() is called", async () => {
       const worker = new Worker(
         upstreamHost,
-        `addEventListener("fetch", (e) => {e.passThroughOnException(); throw "An exception from worker!"})`,
+        `
+        async function handleRequest(event) {
+          throw "An exception from worker!";
+        }
+        addEventListener("fetch", (e) => {
+          e.passThroughOnException();
+          e.respondWith(handleRequest(e));
+        });
+        `,
         { upstreamHost: upstreamHost }
       );
       const response = await worker.executeFetchEvent(`http://${upstreamHost}/success`);

--- a/app/worker.js
+++ b/app/worker.js
@@ -148,7 +148,7 @@ class Worker {
     const fetchEvent = new FetchEvent(buildRequest(url, opts));
     try {
       this.triggerEvent("fetch", fetchEvent);
-      return fetchEvent.__response();
+      return await fetchEvent.__response();
     } catch (ex) {
       if (fetchEvent && fetchEvent.exceptionHandler && fetchEvent.exceptionHandler instanceof Function) {
         return fetchEvent.exceptionHandler();


### PR DESCRIPTION
## Background

Whilst attempting to write a test to ensure that `passThroughOnException` is enabled within a worker.  I noticed that if a error is thrown from within a async function, the `passThroughOnException` doesn't take effect.  

The `fetchEvent.__response();` can return a promise, due to the way that a worker allows `e.respondWith` to accept a function that returns a `Promise<Response>`.   When it is returning a promise and within that promise it is throwing an exception, the catch branch of the `try { .. } catch(ex) { .. do the passThroughOnException}`  isn't called; as the exception has yet to occur as the promise is yet to be awaited on.

## Changes

I've updated a single test that is testing `e.passThroughOnException()` to use an async function with e.respondWith.  With only this change in place; you are able to see that the test breaks.

The fix is to add `await` into the `executeFetchEvent`.

I'm unsure if this is how you would wish to address this, but hopefully it demonstrates the issue.